### PR TITLE
fix failure when opening scalar ref that contains wide character

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -5,10 +5,12 @@ use parent 'Exporter';
 our @EXPORT = qw/ make_parser /;
 
 use Parse::JapanesePostalCode;
+use Encode;
 
 sub make_parser {
     my $data = join "\r\n", @_;
     $data .= "\r\n";
+    $data = Encode::encode_utf8($data);
     open my $fh, '<:utf8', \$data;
     Parse::JapanesePostalCode->new( fh => $fh );
 }


### PR DESCRIPTION
I tried to test your module on perl-5.18.1, and failed.
Because, fail to open scalar-ref that contains wide character in perl-5.18 or later.

```
t/00_compile.t .................... ok   
t/01_simple.t ..................... ok   
t/02_region-split.t ............... Strings with code points over 0xFF may not be mapped into in-memory file handles
readline() on closed filehandle $fh at /home/ytnobody/workspace/duX3oN1/p5-Parse-JapanesePostalCode/lib/Parse/JapanesePostalCode.pm line 50.
Can't call method "pref" on an undefined value at t/02_region-split.t line 40.
t/02_region-split.t ............... Dubious, test returned 22 (wstat 5632, 0x1600)
No subtests run 
t/03_hankaku-zenkaku.t ............ ok   
t/101_normal.t .................... Strings with code points over 0xFF may not be mapped into in-memory file handles
readline() on closed filehandle $fh at /home/ytnobody/workspace/duX3oN1/p5-Parse-JapanesePostalCode/lib/Parse/JapanesePostalCode.pm line 50.
Can't call method "region_id" on an undefined value at t/101_normal.t line 15.
    # Child (sapporo) exited without calling finalize()
t/101_normal.t .................... 1/? 
#   Failed test 'sapporo'
#   at /home/ytnobody/.plenv/versions/5.18.1/lib/perl5/5.18.1/Test/Builder.pm line 252.
# Tests were run but no plan was declared and done_testing() was not seen.
t/101_normal.t .................... Dubious, test returned 29 (wstat 7424, 0x1d00)
Failed 1/1 subtests 
t/102_ikanikisaiganaibaai.t ....... Strings with code points over 0xFF may not be mapped into in-memory file handles
readline() on closed filehandle $fh at /home/ytnobody/workspace/duX3oN1/p5-Parse-JapanesePostalCode/lib/Parse/JapanesePostalCode.pm line 50.
Can't call method "zip" on an undefined value at t/102_ikanikisaiganaibaai.t line 9.
t/102_ikanikisaiganaibaai.t ....... Dubious, test returned 22 (wstat 5632, 0x1600)
No subtests run 
t/103_build.t ..................... Strings with code points over 0xFF may not be mapped into in-memory file handles
readline() on closed filehandle $fh at /home/ytnobody/workspace/duX3oN1/p5-Parse-JapanesePostalCode/lib/Parse/JapanesePostalCode.pm line 50.
Can't call method "zip" on an undefined value at t/103_build.t line 20.
    # Child (other) exited without calling finalize()
t/103_build.t ..................... 1/? 
#   Failed test 'other'
#   at /home/ytnobody/.plenv/versions/5.18.1/lib/perl5/5.18.1/Test/Builder.pm line 252.
# Tests were run but no plan was declared and done_testing() was not seen.
t/103_build.t ..................... Dubious, test returned 29 (wstat 7424, 0x1d00)
Failed 1/1 subtests 
t/104_other.t ..................... Strings with code points over 0xFF may not be mapped into in-memory file handles
readline() on closed filehandle $fh at /home/ytnobody/workspace/duX3oN1/p5-Parse-JapanesePostalCode/lib/Parse/JapanesePostalCode.pm line 50.
Can't call method "town" on an undefined value at t/104_other.t line 12.
    # Child (other) exited without calling finalize()
t/104_other.t ..................... 1/? 
#   Failed test 'other'
#   at /home/ytnobody/.plenv/versions/5.18.1/lib/perl5/5.18.1/Test/Builder.pm line 252.
# Tests were run but no plan was declared and done_testing() was not seen.
t/104_other.t ..................... Dubious, test returned 29 (wstat 7424, 0x1d00)
Failed 1/1 subtests 
t/105_chome.t ..................... Strings with code points over 0xFF may not be mapped into in-memory file handles
readline() on closed filehandle $fh at /home/ytnobody/workspace/duX3oN1/p5-Parse-JapanesePostalCode/lib/Parse/JapanesePostalCode.pm line 50.
Can't call method "town" on an undefined value at t/105_chome.t line 15.
    # Child (single) exited without calling finalize()
t/105_chome.t ..................... 1/? 
#   Failed test 'single'
#   at /home/ytnobody/.plenv/versions/5.18.1/lib/perl5/5.18.1/Test/Builder.pm line 252.
# Tests were run but no plan was declared and done_testing() was not seen.
t/105_chome.t ..................... Dubious, test returned 29 (wstat 7424, 0x1d00)
Failed 1/1 subtests 
t/106_banchi.t .................... Strings with code points over 0xFF may not be mapped into in-memory file handles
readline() on closed filehandle $fh at /home/ytnobody/workspace/duX3oN1/p5-Parse-JapanesePostalCode/lib/Parse/JapanesePostalCode.pm line 50.
Can't call method "town" on an undefined value at t/106_banchi.t line 17.
t/106_banchi.t .................... Dubious, test returned 22 (wstat 5632, 0x1600)
No subtests run 
t/107_chiwari.t ................... Strings with code points over 0xFF may not be mapped into in-memory file handles
readline() on closed filehandle $fh at /home/ytnobody/workspace/duX3oN1/p5-Parse-JapanesePostalCode/lib/Parse/JapanesePostalCode.pm line 50.
Can't call method "town" on an undefined value at t/107_chiwari.t line 16.
t/107_chiwari.t ................... Dubious, test returned 22 (wstat 5632, 0x1600)
No subtests run 
t/108_ichien.t .................... Strings with code points over 0xFF may not be mapped into in-memory file handles
readline() on closed filehandle $fh at /home/ytnobody/workspace/duX3oN1/p5-Parse-JapanesePostalCode/lib/Parse/JapanesePostalCode.pm line 50.
Can't call method "zip" on an undefined value at t/108_ichien.t line 14.
t/108_ichien.t .................... Dubious, test returned 22 (wstat 5632, 0x1600)
No subtests run 
t/109_subtown-basic.t ............. Strings with code points over 0xFF may not be mapped into in-memory file handles
readline() on closed filehandle $fh at /home/ytnobody/workspace/duX3oN1/p5-Parse-JapanesePostalCode/lib/Parse/JapanesePostalCode.pm line 50.
Can't call method "town" on an undefined value at t/109_subtown-basic.t line 60.
t/109_subtown-basic.t ............. Dubious, test returned 22 (wstat 5632, 0x1600)
No subtests run 
t/110_multiline.t ................. Strings with code points over 0xFF may not be mapped into in-memory file handles
readline() on closed filehandle $fh at /home/ytnobody/workspace/duX3oN1/p5-Parse-JapanesePostalCode/lib/Parse/JapanesePostalCode.pm line 50.
Can't call method "town" on an undefined value at t/110_multiline.t line 57.
t/110_multiline.t ................. Dubious, test returned 22 (wstat 5632, 0x1600)
No subtests run 
t/111_notuginibanchigakurubaai.t .. Strings with code points over 0xFF may not be mapped into in-memory file handles
readline() on closed filehandle $fh at /home/ytnobody/workspace/duX3oN1/p5-Parse-JapanesePostalCode/lib/Parse/JapanesePostalCode.pm line 50.
Can't call method "zip" on an undefined value at t/111_notuginibanchigakurubaai.t line 13.
t/111_notuginibanchigakurubaai.t .. Dubious, test returned 22 (wstat 5632, 0x1600)
No subtests run 

Test Summary Report
-------------------
t/02_region-split.t             (Wstat: 5632 Tests: 0 Failed: 0)
  Non-zero exit status: 22
  Parse errors: No plan found in TAP output
t/101_normal.t                  (Wstat: 7424 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 29
  Parse errors: No plan found in TAP output
t/102_ikanikisaiganaibaai.t     (Wstat: 5632 Tests: 0 Failed: 0)
  Non-zero exit status: 22
  Parse errors: No plan found in TAP output
t/103_build.t                   (Wstat: 7424 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 29
  Parse errors: No plan found in TAP output
t/104_other.t                   (Wstat: 7424 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 29
  Parse errors: No plan found in TAP output
t/105_chome.t                   (Wstat: 7424 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 29
  Parse errors: No plan found in TAP output
t/106_banchi.t                  (Wstat: 5632 Tests: 0 Failed: 0)
  Non-zero exit status: 22
  Parse errors: No plan found in TAP output
t/107_chiwari.t                 (Wstat: 5632 Tests: 0 Failed: 0)
  Non-zero exit status: 22
  Parse errors: No plan found in TAP output
t/108_ichien.t                  (Wstat: 5632 Tests: 0 Failed: 0)
  Non-zero exit status: 22
  Parse errors: No plan found in TAP output
t/109_subtown-basic.t           (Wstat: 5632 Tests: 0 Failed: 0)
  Non-zero exit status: 22
  Parse errors: No plan found in TAP output
t/110_multiline.t               (Wstat: 5632 Tests: 0 Failed: 0)
  Non-zero exit status: 22
  Parse errors: No plan found in TAP output
t/111_notuginibanchigakurubaai.t (Wstat: 5632 Tests: 0 Failed: 0)
  Non-zero exit status: 22
  Parse errors: No plan found in TAP output
Files=15, Tests=10,  1 wallclock secs ( 0.04 usr  0.02 sys +  0.36 cusr  0.07 csys =  0.49 CPU)
Result: FAIL
```
