### PR TITLE
Fix bug to stop to add a same town_kana string over again

### DIFF
--- a/lib/Parse/JapanesePostalCode.pm
+++ b/lib/Parse/JapanesePostalCode.pm
@@ -68,12 +68,14 @@ sub get_line {
     my $row = $self->_get_line;
     return unless $row;
     if ($row->[8] =~ /（.+[^）]$/) {
+        my $past_town_kana = "";
         while (1) {
             my $tmp = $self->_get_line;
             return unless $tmp;
-            $row->[5] .= $tmp->[5];
+            $row->[5] .= $tmp->[5] unless ($past_town_kana ne $tmp->[5]);
             $row->[8] .= $tmp->[8];
             last if $row->[8] =~ /\）$/;
+            $past_town_kana = $tmp->[5];
         }
     }
 


### PR DESCRIPTION
前の行とまったく同じtown_kanaの文字列を繰り返し足さないようにチェックを足しました。
京都市下京区材木町のエントリで修正できたことを確認しました。